### PR TITLE
Add "HandleCompatible" attribute to base SPOT classes

### DIFF
--- a/@opSpot/opSpot.m
+++ b/@opSpot/opSpot.m
@@ -1,4 +1,4 @@
-classdef opSpot
+classdef (HandleCompatible) opSpot
     %opSpot  Spot operator super class.
     %
     %   A = opSpot  creates an empty Spot operator.

--- a/opOrthogonal.m
+++ b/opOrthogonal.m
@@ -1,4 +1,4 @@
-classdef opOrthogonal < opSpot
+classdef (HandleCompatible) opOrthogonal < opSpot
 %OPORTHOGONAL   Abstract class for orthogonal operators.
 %
 %   opOrthogonal methods:


### PR DESCRIPTION
I've made the base **opSpot** and **opOrthogonal** classes carry the "HandleCompatible" attribute. This is so that user-defined SPOT operators can additionally inherit from the **handle** superclass, should it choose to do so. 

Sometimes custom operators simply carry a lot of attributes that need to be persistent, or have large attributes that should never be copied in memory. In such cases it is probably best for these operators to be handle classes, especially when it is never meant to be used with outside code.

Note that this _does not_ make **opSpot** and **opOrthogonal** themselves handle classes. The HandleCompatible attribute also does not automatically persist through subclassing, so only direct subclasses of **opSpot** and **opOrthogonal** are allowed to be handle classes.

All existing unit tests pass with this change.
