### PR TITLE
The base opSpot applyMultiply() function does not preallocate array with same datatype as x

### DIFF
--- a/@opSpot/opSpot.m
+++ b/@opSpot/opSpot.m
@@ -84,9 +84,9 @@ classdef opSpot
             % For border case: empty x
             if isempty(x)
                 if mode == 1
-                    y = zeros(op.m,0);
+                    y = zeros(op.m,0,class(x));
                 else
-                    y = zeros(op.n,0);
+                    y = zeros(op.n,0,class(x));
                 end
                 return
             end
@@ -100,11 +100,11 @@ classdef opSpot
                 if q > 1
                     if isscalar(op)
                         % special case: allocate result size of x
-                        y = zeros(size(x));
+                        y = zeros(size(x),class(x));
                     elseif mode==1
-                        y = zeros(op.m,q);
+                        y = zeros(op.m,q,class(x));
                     else
-                        y = zeros(op.n,q);
+                        y = zeros(op.n,q,class(x));
                     end
                 end
                 


### PR DESCRIPTION
See the title. This should be fairly straightforward.
